### PR TITLE
Add image carousel modal for artists with multiple images

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ pnpm lint         # Run ESLint
 ### Adding a New Artist
 
 1. **Create Artist Profile**: Add a new markdown file in `content/artists/`
-
    - Filename format: `{house_number}-{artist-name}.md` (recommended for organization)
    - Example: `42-jane-doe.md`
    - Note: Filename doesn't affect functionality - artists are sorted by `house_number` field
@@ -143,7 +142,6 @@ house_number: 42 # House number (determines display order)
 ### Adding a Course
 
 1. **Create Course File**: Add markdown file in `content/courses/`
-
    - Filename format: `{artist_house_number}-{course-name}.md` (recommended for organization)
    - Example: `42-pottery-workshop.md`
    - Note: Filename doesn't affect functionality - courses are sorted by linked artist's `house_number`
@@ -178,7 +176,6 @@ Multiple paragraphs are supported, but markdown formatting is not rendered.
 ### Adding Expositions
 
 1. **Create Exposition File**: Add markdown file in `content/expositions/`
-
    - Filename format: `expo-YYYY-season.md` or descriptive name
    - Example: `expo-2024-spring.md`, `expo-winter-showcase.md`
 
@@ -232,7 +229,6 @@ Multiple paragraphs supported.
 ### Adding Events
 
 1. **Create Event File**: Add markdown file in `content/agenda/`
-
    - Filename format: `MMDD-event-name.md`
    - Example: `0529-jubileum-15-jaar.md`
 
@@ -417,13 +413,11 @@ This project is hosted on Vercel with automatic preview deployments for every pu
 #### For Content Changes (Non-Technical Users)
 
 1. **Fork the Repository**
-
    - Go to the GitHub repository page
    - Click the "Fork" button in the top-right corner
    - This creates your own copy of the repository
 
 2. **Make Your Changes**
-
    - Navigate to your forked repository
    - Edit files directly in the GitHub web interface
    - Add new artists, update courses, or modify content as needed

--- a/components.json
+++ b/components.json
@@ -12,7 +12,7 @@
   },
   "aliases": {
     "components": "~/components",
-    "utils": "~/lib/utils",
+    "utils": "~/utils",
     "ui": "~/components/ui",
     "lib": "~/lib",
     "hooks": "~/hooks"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,16 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import { defineConfig, globalIgnores } from "eslint/config";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
-
-const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
-];
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  // Override default ignores of eslint-config-next.
+  globalIgnores([
+    // Default ignores of eslint-config-next:
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts",
+  ]),
+]);
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "de-kersenboomgaard",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "license": "MIT",
   "description": "Website for De Kersenboomgaard artist community in Utrecht. Code is MIT licensed, artist content is protected by copyright.",
   "author": "Thijs Koerselman",
@@ -15,7 +16,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "format": "prettier --write .",
     "test": "echo \"Error: no test specified\" && exit 0"
   },
@@ -53,5 +54,5 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3"
   },
-  "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"
+  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a"
 }

--- a/src/app/components/artist-card.tsx
+++ b/src/app/components/artist-card.tsx
@@ -91,7 +91,10 @@ export function ArtistCard({ artist }: { artist: Artist }) {
                 {artist.name} Gallery
               </DialogTitle>
               <div className="flex h-full w-full items-center justify-center px-12 sm:px-16">
-                <Carousel className="w-full">
+                <Carousel
+                  className="w-full"
+                  opts={{ startIndex: currentImageIndex }}
+                >
                   <CarouselContent>
                     {images.map((image, index) => (
                       <CarouselItem key={image}>

--- a/src/app/components/artist-card.tsx
+++ b/src/app/components/artist-card.tsx
@@ -70,6 +70,7 @@ export function ArtistCard({ artist }: { artist: Artist }) {
               <button
                 type="button"
                 className="relative h-[120px] w-[120px] cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
+                aria-label={`View all images of ${artist.name}`}
               >
                 {images.map((image, index) => (
                   <Image

--- a/src/app/components/artist-card.tsx
+++ b/src/app/components/artist-card.tsx
@@ -93,7 +93,7 @@ export function ArtistCard({ artist }: { artist: Artist }) {
                 <Carousel className="w-full">
                   <CarouselContent>
                     {images.map((image, index) => (
-                      <CarouselItem key={index}>
+                      <CarouselItem key={image}>
                         <div className="relative h-[80vh] w-full sm:h-[70vh] sm:max-h-[600px]">
                           <Image
                             src={image}

--- a/src/app/components/artist-card.tsx
+++ b/src/app/components/artist-card.tsx
@@ -85,7 +85,7 @@ export function ArtistCard({ artist }: { artist: Artist }) {
                 ))}
               </button>
             </DialogTrigger>
-            <DialogContent className="h-[100dvh] w-screen max-w-none border-none bg-transparent p-0 shadow-none sm:h-auto sm:w-[90vw] sm:max-w-4xl sm:p-4 [&>button]:absolute [&>button]:right-4 [&>button]:top-4 [&>button]:z-50 [&>button]:text-white [&>button]:drop-shadow-md">
+            <DialogContent className="h-[100dvh] w-screen max-w-none border-none bg-transparent p-0 shadow-none sm:h-auto sm:w-[90vw] sm:max-w-4xl sm:p-4 [&>button]:absolute [&>button]:top-4 [&>button]:right-4 [&>button]:z-50 [&>button]:text-white [&>button]:drop-shadow-md">
               <DialogTitle className="sr-only">
                 {artist.name} Gallery
               </DialogTitle>

--- a/src/app/components/artist-card.tsx
+++ b/src/app/components/artist-card.tsx
@@ -17,6 +17,7 @@ import {
   CarouselPrevious,
   CarouselNext,
 } from "~/components/ui/carousel";
+import { useScrollBasedImages } from "~/hooks/use-scroll-based-images";
 
 function formatWebsiteDisplay(link: string): string {
   return link.replace(/^https?:\/\//, "").replace(/^www\./, "");
@@ -30,7 +31,10 @@ export function ArtistCard({ artist }: { artist: Artist }) {
       ? artist.all_images
       : [artist.image, artist.flip_image].filter(Boolean);
 
-  const currentImage = images[0] || "";
+  const { currentImage, currentImageIndex, elementRef } = useScrollBasedImages({
+    images,
+    enabled: images.length > 1,
+  });
 
   const handleMouseEnter = () => {
     setIsHovered(true);
@@ -42,6 +46,7 @@ export function ArtistCard({ artist }: { artist: Artist }) {
 
   return (
     <div
+      ref={elementRef}
       id={`artist-${artist.id}`}
       className="relative flex items-start space-x-4"
       onMouseEnter={handleMouseEnter}
@@ -59,51 +64,63 @@ export function ArtistCard({ artist }: { artist: Artist }) {
         </div>
       )}
       <div className="relative z-10 flex-shrink-0">
-        <Dialog>
-          <DialogTrigger asChild>
-            <button
-              type="button"
-              className="relative h-[120px] w-[120px] cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
-            >
-              <Image
-                src={currentImage || "/placeholder.svg"}
-                alt={artist.name}
-                width={120}
-                height={120}
-                className="h-[120px] w-[120px] border-4 border-white object-cover shadow-lg transition-transform hover:scale-105"
-              />
-            </button>
-          </DialogTrigger>
-          <DialogContent className="max-w-3xl border-none bg-transparent p-0 shadow-none sm:max-w-4xl [&>button]:text-white [&>button]:hover:text-gray-300">
-            <DialogTitle className="sr-only">{artist.name} Gallery</DialogTitle>
-            <Carousel className="w-full">
-              <CarouselContent>
+        {images.length > 1 ? (
+          <Dialog>
+            <DialogTrigger asChild>
+              <button
+                type="button"
+                className="relative h-[120px] w-[120px] cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
+              >
                 {images.map((image, index) => (
-                  <CarouselItem
-                    key={index}
-                    className="flex items-center justify-center"
-                  >
-                    <div className="relative aspect-square h-[50vh] w-full max-w-[80vw] sm:h-[70vh]">
-                      <Image
-                        src={image}
-                        alt={`${artist.name} - Image ${index + 1}`}
-                        fill
-                        className="object-contain"
-                        priority={index === 0}
-                      />
-                    </div>
-                  </CarouselItem>
+                  <Image
+                    key={image}
+                    src={image}
+                    alt={artist.name}
+                    width={120}
+                    height={120}
+                    className={`absolute inset-0 h-[120px] w-[120px] border-4 border-white object-cover shadow-lg transition-opacity duration-300 ${
+                      index === currentImageIndex ? "opacity-100" : "opacity-0"
+                    }`}
+                  />
                 ))}
-              </CarouselContent>
-              {images.length > 1 && (
-                <>
-                  <CarouselPrevious className="left-2 border-none bg-white/80 hover:bg-white sm:left-4" />
-                  <CarouselNext className="right-2 border-none bg-white/80 hover:bg-white sm:right-4" />
-                </>
-              )}
-            </Carousel>
-          </DialogContent>
-        </Dialog>
+              </button>
+            </DialogTrigger>
+            <DialogContent className="h-[100dvh] w-screen max-w-none border-none bg-transparent p-0 shadow-none sm:h-auto sm:w-[90vw] sm:max-w-4xl sm:p-4 [&>button]:absolute [&>button]:right-4 [&>button]:top-4 [&>button]:z-50 [&>button]:text-white [&>button]:drop-shadow-md">
+              <DialogTitle className="sr-only">
+                {artist.name} Gallery
+              </DialogTitle>
+              <div className="flex h-full w-full items-center justify-center px-12 sm:px-16">
+                <Carousel className="w-full">
+                  <CarouselContent>
+                    {images.map((image, index) => (
+                      <CarouselItem key={index}>
+                        <div className="relative h-[80vh] w-full sm:h-[70vh] sm:max-h-[600px]">
+                          <Image
+                            src={image}
+                            alt={`${artist.name} - Image ${index + 1}`}
+                            fill
+                            className="object-contain"
+                            priority={index === 0}
+                          />
+                        </div>
+                      </CarouselItem>
+                    ))}
+                  </CarouselContent>
+                  <CarouselPrevious className="-left-10 border-none bg-white/90 shadow-md hover:bg-white sm:-left-12" />
+                  <CarouselNext className="-right-10 border-none bg-white/90 shadow-md hover:bg-white sm:-right-12" />
+                </Carousel>
+              </div>
+            </DialogContent>
+          </Dialog>
+        ) : (
+          <Image
+            src={currentImage || "/placeholder.svg"}
+            alt={artist.name}
+            width={120}
+            height={120}
+            className="h-[120px] w-[120px] border-4 border-white object-cover shadow-lg"
+          />
+        )}
       </div>
       <div className="relative z-10 min-w-0 flex-1">
         <h3 className="mb-1 text-xl font-medium text-gray-900">

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
-import { cn } from "~/lib/utils"
+import { cn } from "~/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -33,8 +33,8 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -44,9 +44,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot : "button"
+  const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
@@ -54,7 +54,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,45 +1,45 @@
-"use client"
+"use client";
 
-import * as React from "react"
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
-} from "embla-carousel-react"
-import { ArrowLeft, ArrowRight } from "lucide-react"
+} from "embla-carousel-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import * as React from "react";
 
-import { cn } from "~/lib/utils"
-import { Button } from "~/components/ui/button"
+import { Button } from "~/components/ui/button";
+import { cn } from "~/utils";
 
-type CarouselApi = UseEmblaCarouselType[1]
-type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
-type CarouselOptions = UseCarouselParameters[0]
-type CarouselPlugin = UseCarouselParameters[1]
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
 
 type CarouselProps = {
-  opts?: CarouselOptions
-  plugins?: CarouselPlugin
-  orientation?: "horizontal" | "vertical"
-  setApi?: (api: CarouselApi) => void
-}
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: "horizontal" | "vertical";
+  setApi?: (api: CarouselApi) => void;
+};
 
 type CarouselContextProps = {
-  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
-  api: ReturnType<typeof useEmblaCarousel>[1]
-  scrollPrev: () => void
-  scrollNext: () => void
-  canScrollPrev: boolean
-  canScrollNext: boolean
-} & CarouselProps
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
 
-const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
 
 function useCarousel() {
-  const context = React.useContext(CarouselContext)
+  const context = React.useContext(CarouselContext);
 
   if (!context) {
-    throw new Error("useCarousel must be used within a <Carousel />")
+    throw new Error("useCarousel must be used within a <Carousel />");
   }
 
-  return context
+  return context;
 }
 
 function Carousel({
@@ -56,53 +56,53 @@ function Carousel({
       ...opts,
       axis: orientation === "horizontal" ? "x" : "y",
     },
-    plugins
-  )
-  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
-  const [canScrollNext, setCanScrollNext] = React.useState(false)
+    plugins,
+  );
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+  const [canScrollNext, setCanScrollNext] = React.useState(false);
 
   const onSelect = React.useCallback((api: CarouselApi) => {
-    if (!api) return
-    setCanScrollPrev(api.canScrollPrev())
-    setCanScrollNext(api.canScrollNext())
-  }, [])
+    if (!api) return;
+    setCanScrollPrev(api.canScrollPrev());
+    setCanScrollNext(api.canScrollNext());
+  }, []);
 
   const scrollPrev = React.useCallback(() => {
-    api?.scrollPrev()
-  }, [api])
+    api?.scrollPrev();
+  }, [api]);
 
   const scrollNext = React.useCallback(() => {
-    api?.scrollNext()
-  }, [api])
+    api?.scrollNext();
+  }, [api]);
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (event.key === "ArrowLeft") {
-        event.preventDefault()
-        scrollPrev()
+        event.preventDefault();
+        scrollPrev();
       } else if (event.key === "ArrowRight") {
-        event.preventDefault()
-        scrollNext()
+        event.preventDefault();
+        scrollNext();
       }
     },
-    [scrollPrev, scrollNext]
-  )
+    [scrollPrev, scrollNext],
+  );
 
   React.useEffect(() => {
-    if (!api || !setApi) return
-    setApi(api)
-  }, [api, setApi])
+    if (!api || !setApi) return;
+    setApi(api);
+  }, [api, setApi]);
 
   React.useEffect(() => {
-    if (!api) return
-    onSelect(api)
-    api.on("reInit", onSelect)
-    api.on("select", onSelect)
+    if (!api) return;
+    onSelect(api);
+    api.on("reInit", onSelect);
+    api.on("select", onSelect);
 
     return () => {
-      api?.off("select", onSelect)
-    }
-  }, [api, onSelect])
+      api?.off("select", onSelect);
+    };
+  }, [api, onSelect]);
 
   return (
     <CarouselContext.Provider
@@ -129,11 +129,11 @@ function Carousel({
         {children}
       </div>
     </CarouselContext.Provider>
-  )
+  );
 }
 
 function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
-  const { carouselRef, orientation } = useCarousel()
+  const { carouselRef, orientation } = useCarousel();
 
   return (
     <div
@@ -145,16 +145,16 @@ function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
         className={cn(
           "flex",
           orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
-          className
+          className,
         )}
         {...props}
       />
     </div>
-  )
+  );
 }
 
 function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
-  const { orientation } = useCarousel()
+  const { orientation } = useCarousel();
 
   return (
     <div
@@ -164,11 +164,11 @@ function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
       className={cn(
         "min-w-0 shrink-0 grow-0 basis-full",
         orientation === "horizontal" ? "pl-4" : "pt-4",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CarouselPrevious({
@@ -177,7 +177,7 @@ function CarouselPrevious({
   size = "icon",
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
 
   return (
     <Button
@@ -189,7 +189,7 @@ function CarouselPrevious({
         orientation === "horizontal"
           ? "top-1/2 -left-12 -translate-y-1/2"
           : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
-        className
+        className,
       )}
       disabled={!canScrollPrev}
       onClick={scrollPrev}
@@ -198,7 +198,7 @@ function CarouselPrevious({
       <ArrowLeft />
       <span className="sr-only">Previous slide</span>
     </Button>
-  )
+  );
 }
 
 function CarouselNext({
@@ -207,7 +207,7 @@ function CarouselNext({
   size = "icon",
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { orientation, scrollNext, canScrollNext } = useCarousel()
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
 
   return (
     <Button
@@ -219,7 +219,7 @@ function CarouselNext({
         orientation === "horizontal"
           ? "top-1/2 -right-12 -translate-y-1/2"
           : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
-        className
+        className,
       )}
       disabled={!canScrollNext}
       onClick={scrollNext}
@@ -228,14 +228,14 @@ function CarouselNext({
       <ArrowRight />
       <span className="sr-only">Next slide</span>
     </Button>
-  )
+  );
 }
 
 export {
-  type CarouselApi,
   Carousel,
   CarouselContent,
   CarouselItem,
-  CarouselPrevious,
   CarouselNext,
-}
+  CarouselPrevious,
+  type CarouselApi,
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-1/2 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
+        "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
         className,
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "~/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-1/2 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg leading-none font-semibold tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-muted-foreground text-sm", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/src/hooks/use-scroll-based-images.tsx
+++ b/src/hooks/use-scroll-based-images.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface UseScrollBasedImagesProps {
   images: string[];
@@ -11,63 +11,88 @@ export function useScrollBasedImages({
   images,
   enabled = true,
 }: UseScrollBasedImagesProps) {
-  const [currentImageIndex, setCurrentImageIndex] = useState(0);
-  const [initialPosition, setInitialPosition] = useState<number | null>(null);
+  /** Create a stable key from images array for dependency tracking */
+  const imagesKey = useMemo(() => images.join(","), [images]);
+
+  const [state, setState] = useState(() => ({
+    currentImageIndex: 0,
+    imagesKey,
+  }));
+
+  const initialPositionRef = useRef<number | null>(null);
+  const lastImagesKeyRef = useRef(imagesKey);
   const elementRef = useRef<HTMLDivElement>(null);
+
+  /** Reset when images change by checking key mismatch */
+  const currentImageIndex =
+    state.imagesKey === imagesKey ? state.currentImageIndex : 0;
+
+  const setCurrentImageIndex = useCallback(
+    (index: number) => {
+      setState({ currentImageIndex: index, imagesKey });
+    },
+    [imagesKey],
+  );
+
+  const handleScroll = useCallback(() => {
+    const element = elementRef.current;
+    if (!element) return;
+
+    /** Reset initial position when images change */
+    if (lastImagesKeyRef.current !== imagesKey) {
+      lastImagesKeyRef.current = imagesKey;
+      initialPositionRef.current = null;
+    }
+
+    const rect = element.getBoundingClientRect();
+    const avatarCenter = rect.top + rect.height / 2;
+    const viewportHeight = window.innerHeight;
+    const viewportCenter = viewportHeight / 2;
+
+    /** Store initial position when element first becomes visible */
+    if (initialPositionRef.current === null && avatarCenter < viewportHeight) {
+      initialPositionRef.current = avatarCenter;
+      return;
+    }
+
+    /** Only calculate if we have an initial position */
+    if (initialPositionRef.current === null) return;
+
+    const initialPosition = initialPositionRef.current;
+
+    /** Determine travel distance based on initial position */
+    let travelDistance: number;
+
+    if (initialPosition <= viewportHeight) {
+      /** Artist was initially visible - travel from initial position to top */
+      travelDistance = Math.max(initialPosition, 100);
+    } else {
+      /** Artist was initially outside viewport - travel from initial position to viewport center */
+      travelDistance = initialPosition - viewportCenter;
+    }
+
+    /** Calculate current progress (0 = at initial position, 1 = at target position) */
+    const scrollProgress = Math.max(
+      0,
+      Math.min(1, (initialPosition - avatarCenter) / travelDistance),
+    );
+
+    /** Map progress to image index */
+    const imageIndex = Math.floor(scrollProgress * images.length);
+    const clampedIndex = Math.max(0, Math.min(images.length - 1, imageIndex));
+
+    setCurrentImageIndex(clampedIndex);
+  }, [images.length, imagesKey, setCurrentImageIndex]);
 
   useEffect(() => {
     if (!enabled || images.length <= 1) {
       return;
     }
 
-    const element = elementRef.current;
-    if (!element) return;
-
-    const handleScroll = () => {
-      const rect = element.getBoundingClientRect();
-      const avatarCenter = rect.top + rect.height / 2; // Use center of avatar
-      const viewportHeight = window.innerHeight;
-      const viewportCenter = viewportHeight / 2;
-
-      // Store initial position when element first becomes visible
-      if (initialPosition === null && avatarCenter < viewportHeight) {
-        setInitialPosition(avatarCenter);
-        return;
-      }
-
-      // Only calculate if we have an initial position
-      if (initialPosition === null) return;
-
-      // Determine travel distance based on initial position
-      let travelDistance: number;
-
-      if (initialPosition <= viewportHeight) {
-        // Artist was initially visible - travel from initial position to top
-        travelDistance = Math.max(initialPosition, 100);
-      } else {
-        // Artist was initially outside viewport - travel from initial position to viewport center
-        travelDistance = initialPosition - viewportCenter;
-      }
-
-      // Calculate current progress (0 = at initial position, 1 = at target position)
-      const scrollProgress = Math.max(
-        0,
-        Math.min(1, (initialPosition - avatarCenter) / travelDistance),
-      );
-
-      // Map progress to image index
-      // 0% scroll = first image (alphabetically first)
-      // 100% scroll = last image (alphabetically last)
-      const imageIndex = Math.floor(scrollProgress * images.length);
-      const clampedIndex = Math.max(0, Math.min(images.length - 1, imageIndex));
-
-      setCurrentImageIndex(clampedIndex);
-    };
-
-    // Initial check
+    /** Initial check */
     handleScroll();
 
-    // Add scroll listener with throttling for better performance
+    /** Add scroll listener with throttling for better performance */
     let ticking = false;
     const throttledHandleScroll = () => {
       if (!ticking) {
@@ -84,13 +109,7 @@ export function useScrollBasedImages({
     return () => {
       window.removeEventListener("scroll", throttledHandleScroll);
     };
-  }, [enabled, images.length, initialPosition]);
-
-  // Reset when images change
-  useEffect(() => {
-    setCurrentImageIndex(0);
-    setInitialPosition(null);
-  }, [images]);
+  }, [enabled, images.length, handleScroll]);
 
   return {
     currentImageIndex,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from "./cn";
+export * from "./generate-slug";


### PR DESCRIPTION
Clicking on an artist thumbnail now opens a carousel modal when the artist has more than one image. The carousel allows navigating through all artist images with previous/next buttons.

Changes:
- Artist images with multiple photos show a clickable thumbnail that opens a modal carousel
- Scroll-based image rotation with fade transitions preserved on the thumbnail
- Responsive design: fullscreen on mobile, contained modal on desktop
- Simple fade animation when closing the modal