### PR TITLE
Improve scroll-based image transitions

### DIFF
--- a/src/app/components/artist-card.tsx
+++ b/src/app/components/artist-card.tsx
@@ -23,7 +23,13 @@ function formatWebsiteDisplay(link: string): string {
   return link.replace(/^https?:\/\//, "").replace(/^www\./, "");
 }
 
-export function ArtistCard({ artist }: { artist: Artist }) {
+export function ArtistCard({
+  artist,
+  initialImageOffset = 0,
+}: {
+  artist: Artist;
+  initialImageOffset?: number;
+}) {
   const [isHovered, setIsHovered] = useState(false);
   const carouselRef = useRef<HTMLDivElement>(null);
 
@@ -35,6 +41,7 @@ export function ArtistCard({ artist }: { artist: Artist }) {
   const { currentImage, currentImageIndex } = useScrollBasedImages({
     images,
     enabled: images.length > 1,
+    initialOffset: initialImageOffset,
   });
 
   const handleMouseEnter = () => {

--- a/src/app/components/artist-card.tsx
+++ b/src/app/components/artist-card.tsx
@@ -32,7 +32,7 @@ export function ArtistCard({ artist }: { artist: Artist }) {
       ? artist.all_images
       : [artist.image, artist.flip_image].filter(Boolean);
 
-  const { currentImage, currentImageIndex, elementRef } = useScrollBasedImages({
+  const { currentImage, currentImageIndex } = useScrollBasedImages({
     images,
     enabled: images.length > 1,
   });
@@ -57,7 +57,6 @@ export function ArtistCard({ artist }: { artist: Artist }) {
 
   return (
     <div
-      ref={elementRef}
       id={`artist-${artist.id}`}
       className="relative flex items-start space-x-4"
       onMouseEnter={handleMouseEnter}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,13 +9,29 @@ import { getArtists } from "./helpers/get-artists";
 import { getCourses } from "./helpers/get-courses";
 import { getExpositions } from "./helpers/get-expositions";
 
+/** Ensure fresh random offsets on each request */
+export const dynamic = "force-dynamic";
+
 export default async function Component() {
   const expositions = await getExpositions();
   const artists = await getArtists();
   const courses = await getCourses();
   const agendaItems = await getAgendaItems();
 
-  // Generate structured data for SEO
+  /**
+   * Generate random image offsets server-side for stable hydration.
+   * Math.random() is safe here as server components only render once per request.
+   */
+  const artistImageOffsets = artists.map((artist) => {
+    const imageCount =
+      artist.all_images.length > 0
+        ? artist.all_images.length
+        : [artist.image, artist.flip_image].filter(Boolean).length;
+    // eslint-disable-next-line react-hooks/purity
+    return imageCount > 1 ? Math.floor(Math.random() * imageCount) : 0;
+  });
+
+  /** Generate structured data for SEO */
   const structuredData = generateStructuredData(artists, courses);
 
   return (
@@ -67,7 +83,11 @@ export default async function Component() {
           {/* Artists Grid */}
           <div className="mx-auto grid max-w-4xl grid-cols-1 gap-8 md:grid-cols-2">
             {artists.map((artist, index) => (
-              <ArtistCard key={index} artist={artist} />
+              <ArtistCard
+                key={index}
+                artist={artist}
+                initialImageOffset={artistImageOffsets[index]}
+              />
             ))}
           </div>
 

--- a/src/hooks/use-scroll-based-images.tsx
+++ b/src/hooks/use-scroll-based-images.tsx
@@ -1,96 +1,66 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 interface UseScrollBasedImagesProps {
   images: string[];
   enabled?: boolean;
 }
 
+/** Shared scroll state across all hook instances for synchronized transitions */
+let globalAccumulatedScroll = 0;
+let lastScrollY = typeof window !== "undefined" ? window.scrollY : 0;
+
 export function useScrollBasedImages({
   images,
   enabled = true,
 }: UseScrollBasedImagesProps) {
-  /** Create a stable key from images array for dependency tracking */
-  const imagesKey = useMemo(() => images.join(","), [images]);
-
-  const [state, setState] = useState(() => ({
-    currentImageIndex: 0,
-    imagesKey,
-  }));
-
-  const initialPositionRef = useRef<number | null>(null);
-  const lastImagesKeyRef = useRef(imagesKey);
-  const elementRef = useRef<HTMLDivElement>(null);
-
-  /** Reset when images change by checking key mismatch */
-  const currentImageIndex =
-    state.imagesKey === imagesKey ? state.currentImageIndex : 0;
-
-  const setCurrentImageIndex = useCallback(
-    (index: number) => {
-      setState({ currentImageIndex: index, imagesKey });
-    },
-    [imagesKey],
+  /**
+   * Random offset initialized once per component mount.
+   * This makes each artist potentially start at a different image on page load.
+   */
+  const [randomOffset] = useState(() =>
+    images.length > 0 ? Math.floor(Math.random() * images.length) : 0,
   );
 
+  const [currentImageIndex, setCurrentImageIndex] = useState(randomOffset);
+
   const handleScroll = useCallback(() => {
-    const element = elementRef.current;
-    if (!element) return;
+    /** Calculate pixels per transition: 2 transitions per viewport height */
+    const pixelsPerTransition = window.innerHeight / 2;
 
-    /** Reset initial position when images change */
-    if (lastImagesKeyRef.current !== imagesKey) {
-      lastImagesKeyRef.current = imagesKey;
-      initialPositionRef.current = null;
-    }
+    /** Update global accumulated scroll (both directions count) */
+    const currentScrollY = window.scrollY;
+    const delta = Math.abs(currentScrollY - lastScrollY);
+    lastScrollY = currentScrollY;
+    globalAccumulatedScroll += delta;
 
-    const rect = element.getBoundingClientRect();
-    const avatarCenter = rect.top + rect.height / 2;
-    const viewportHeight = window.innerHeight;
-    const viewportCenter = viewportHeight / 2;
-
-    /** Store initial position when element first becomes visible */
-    if (initialPositionRef.current === null && avatarCenter < viewportHeight) {
-      initialPositionRef.current = avatarCenter;
-      return;
-    }
-
-    /** Only calculate if we have an initial position */
-    if (initialPositionRef.current === null) return;
-
-    const initialPosition = initialPositionRef.current;
-
-    /** Determine travel distance based on initial position */
-    let travelDistance: number;
-
-    if (initialPosition <= viewportHeight) {
-      /** Artist was initially visible - travel from initial position to top */
-      travelDistance = Math.max(initialPosition, 100);
-    } else {
-      /** Artist was initially outside viewport - travel from initial position to viewport center */
-      travelDistance = initialPosition - viewportCenter;
-    }
-
-    /** Calculate current progress (0 = at initial position, 1 = at target position) */
-    const scrollProgress = Math.max(
-      0,
-      Math.min(1, (initialPosition - avatarCenter) / travelDistance),
+    /** Calculate global grid index based on accumulated scroll */
+    const globalIndex = Math.floor(
+      globalAccumulatedScroll / pixelsPerTransition,
     );
-
-    /** Map progress to image index */
-    const imageIndex = Math.floor(scrollProgress * images.length);
-    const clampedIndex = Math.max(0, Math.min(images.length - 1, imageIndex));
-
-    setCurrentImageIndex(clampedIndex);
-  }, [images.length, imagesKey, setCurrentImageIndex]);
+    /** Apply random offset and cycle through images round-robin */
+    const imageIndex = (globalIndex + randomOffset) % images.length;
+    setCurrentImageIndex(imageIndex);
+  }, [images.length, randomOffset]);
 
   useEffect(() => {
     if (!enabled || images.length <= 1) {
       return;
     }
 
-    /** Initial check */
-    handleScroll();
+    /** Initialize last scroll position */
+    lastScrollY = window.scrollY;
+
+    /** Set initial image based on current accumulated scroll (deferred to avoid sync setState) */
+    const initialFrame = requestAnimationFrame(() => {
+      const pixelsPerTransition = window.innerHeight / 2;
+      const globalIndex = Math.floor(
+        globalAccumulatedScroll / pixelsPerTransition,
+      );
+      const imageIndex = (globalIndex + randomOffset) % images.length;
+      setCurrentImageIndex(imageIndex);
+    });
 
     /** Add scroll listener with throttling for better performance */
     let ticking = false;
@@ -107,13 +77,13 @@ export function useScrollBasedImages({
     window.addEventListener("scroll", throttledHandleScroll, { passive: true });
 
     return () => {
+      cancelAnimationFrame(initialFrame);
       window.removeEventListener("scroll", throttledHandleScroll);
     };
-  }, [enabled, images.length, handleScroll]);
+  }, [enabled, images.length, handleScroll, randomOffset]);
 
   return {
     currentImageIndex,
     currentImage: images[currentImageIndex] || images[0] || "",
-    elementRef,
   };
 }


### PR DESCRIPTION
Refactors the scroll-based image hook to use a global accumulated scroll value shared across all artist cards. This ensures all images transition simultaneously at fixed intervals (2 transitions per viewport height).

Changes:
- All artist images now change at the same scroll thresholds
- Scrolling in both directions accumulates to trigger transitions
- Each artist starts at a random image offset on page load
- Removed per-element visibility tracking in favor of global scroll position