### PR TITLE
Improve scroll-based image transitions (PR feedback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,11 @@ house_number: 42 # House number (determines display order)
 ```
 
 3. **Add Artist Images**: Create folder `public/assets/artists/jane-doe/`
-   - Add any number of images with any names
-   - Images are displayed in alphabetical order
-   - All images cycle based on scroll position
+   - Add any number of images (no limit)
+   - Images are sorted alphabetically by filename
+   - Each page load starts at a random image
+   - All images cycle through as users scroll (synchronized across all artists)
+   - Clicking an image opens a carousel to browse all images
    - Supported formats: `.jpg`, `.jpeg`, `.png`
 
 ### Editing via GitHub UI
@@ -277,8 +279,11 @@ public/assets/artists/
 - **Folder Naming**: Use artist ID as folder name (matches `id` in artist frontmatter)
 - **File Naming**: Image filenames don't matter - any name works
 - **Formats**: JPG, JPEG, PNG supported
+- **No Limit**: Add as many images as you want per artist
 - **Display Order**: Images are sorted alphabetically by filename
-- **Scroll-Based Display**: All images cycle equally based on scroll position
+- **Random Start**: Each page load begins at a random image per artist
+- **Scroll-Based Cycling**: Images cycle through as users scroll (synchronized across all artists)
+- **Full Access**: Clicking any artist image opens a carousel to browse all their images
 - **Fallbacks**: Missing images handled gracefully with placeholders
 
 ### Adding Images via GitHub

--- a/src/app/components/artist-card.tsx
+++ b/src/app/components/artist-card.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Carousel,
   CarouselContent,
@@ -23,14 +23,16 @@ function formatWebsiteDisplay(link: string): string {
   return link.replace(/^https?:\/\//, "").replace(/^www\./, "");
 }
 
-export function ArtistCard({
-  artist,
-  initialImageOffset = 0,
-}: {
-  artist: Artist;
-  initialImageOffset?: number;
-}) {
+/** Skeleton placeholder for image loading state */
+function ImageSkeleton() {
+  return (
+    <div className="h-[120px] w-[120px] animate-pulse border-4 border-white bg-gray-200 shadow-[0_2px_8px_rgba(0,0,0,0.15)]" />
+  );
+}
+
+export function ArtistCard({ artist }: { artist: Artist }) {
   const [isHovered, setIsHovered] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
   const carouselRef = useRef<HTMLDivElement>(null);
 
   const images =
@@ -38,11 +40,24 @@ export function ArtistCard({
       ? artist.all_images
       : [artist.image, artist.flip_image].filter(Boolean);
 
+  /** Generate random offset client-side only to avoid hydration mismatch */
+  const [randomOffset] = useState(() =>
+    images.length > 1 ? Math.floor(Math.random() * images.length) : 0,
+  );
+
   const { currentImage, currentImageIndex } = useScrollBasedImages({
     images,
-    enabled: images.length > 1,
-    initialOffset: initialImageOffset,
+    enabled: isMounted && images.length > 1,
+    initialOffset: randomOffset,
   });
+
+  /** Mark as mounted after hydration (deferred to satisfy lint rules) */
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      setIsMounted(true);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, []);
 
   const handleMouseEnter = () => {
     setIsHovered(true);
@@ -62,6 +77,79 @@ export function ArtistCard({
     }
   }, []);
 
+  /** Render image content - skeleton until mounted, then actual images */
+  const renderImageContent = () => {
+    if (!isMounted) {
+      return <ImageSkeleton />;
+    }
+
+    if (images.length > 1) {
+      return (
+        <Dialog onOpenChange={handleDialogOpen}>
+          <DialogTrigger asChild>
+            <button
+              type="button"
+              className="relative h-[120px] w-[120px] cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
+              aria-label={`View all images of ${artist.name}`}
+            >
+              {images.map((image, index) => (
+                <Image
+                  key={image}
+                  src={image}
+                  alt={artist.name}
+                  width={120}
+                  height={120}
+                  className={`absolute inset-0 h-[120px] w-[120px] border-4 border-white object-cover shadow-[0_2px_8px_rgba(0,0,0,0.15)] transition-opacity duration-300 ${
+                    index === currentImageIndex ? "opacity-100" : "opacity-0"
+                  }`}
+                />
+              ))}
+            </button>
+          </DialogTrigger>
+          <DialogContent className="h-[100dvh] w-screen max-w-none border-none bg-transparent p-0 shadow-none sm:h-auto sm:w-[90vw] sm:max-w-4xl sm:p-4 [&>button]:absolute [&>button]:top-4 [&>button]:right-4 [&>button]:z-50 [&>button]:text-white [&>button]:drop-shadow-md">
+            <DialogTitle className="sr-only">{artist.name} Gallery</DialogTitle>
+            <div className="flex h-full w-full items-center justify-center px-12 sm:px-16">
+              <Carousel
+                ref={carouselRef}
+                className="w-full outline-none"
+                opts={{ startIndex: currentImageIndex, loop: true }}
+                tabIndex={0}
+              >
+                <CarouselContent>
+                  {images.map((image, index) => (
+                    <CarouselItem key={image}>
+                      <div className="relative h-[80vh] w-full sm:h-[70vh] sm:max-h-[600px]">
+                        <Image
+                          src={image}
+                          alt={`${artist.name} - Image ${index + 1}`}
+                          fill
+                          className="object-contain"
+                          priority={index === 0}
+                        />
+                      </div>
+                    </CarouselItem>
+                  ))}
+                </CarouselContent>
+                <CarouselPrevious className="-left-10 border-none bg-white/90 shadow-md hover:bg-white sm:-left-12" />
+                <CarouselNext className="-right-10 border-none bg-white/90 shadow-md hover:bg-white sm:-right-12" />
+              </Carousel>
+            </div>
+          </DialogContent>
+        </Dialog>
+      );
+    }
+
+    return (
+      <Image
+        src={currentImage || "/placeholder.svg"}
+        alt={artist.name}
+        width={120}
+        height={120}
+        className="h-[120px] w-[120px] border-4 border-white object-cover shadow-[0_2px_8px_rgba(0,0,0,0.15)]"
+      />
+    );
+  };
+
   return (
     <div
       id={`artist-${artist.id}`}
@@ -80,71 +168,7 @@ export function ArtistCard({
           {artist.house_number}
         </div>
       )}
-      <div className="relative z-10 flex-shrink-0">
-        {images.length > 1 ? (
-          <Dialog onOpenChange={handleDialogOpen}>
-            <DialogTrigger asChild>
-              <button
-                type="button"
-                className="relative h-[120px] w-[120px] cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
-                aria-label={`View all images of ${artist.name}`}
-              >
-                {images.map((image, index) => (
-                  <Image
-                    key={image}
-                    src={image}
-                    alt={artist.name}
-                    width={120}
-                    height={120}
-                    className={`absolute inset-0 h-[120px] w-[120px] border-4 border-white object-cover shadow-[0_2px_8px_rgba(0,0,0,0.15)] transition-opacity duration-300 ${
-                      index === currentImageIndex ? "opacity-100" : "opacity-0"
-                    }`}
-                  />
-                ))}
-              </button>
-            </DialogTrigger>
-            <DialogContent className="h-[100dvh] w-screen max-w-none border-none bg-transparent p-0 shadow-none sm:h-auto sm:w-[90vw] sm:max-w-4xl sm:p-4 [&>button]:absolute [&>button]:top-4 [&>button]:right-4 [&>button]:z-50 [&>button]:text-white [&>button]:drop-shadow-md">
-              <DialogTitle className="sr-only">
-                {artist.name} Gallery
-              </DialogTitle>
-              <div className="flex h-full w-full items-center justify-center px-12 sm:px-16">
-                <Carousel
-                  ref={carouselRef}
-                  className="w-full outline-none"
-                  opts={{ startIndex: currentImageIndex, loop: true }}
-                  tabIndex={0}
-                >
-                  <CarouselContent>
-                    {images.map((image, index) => (
-                      <CarouselItem key={image}>
-                        <div className="relative h-[80vh] w-full sm:h-[70vh] sm:max-h-[600px]">
-                          <Image
-                            src={image}
-                            alt={`${artist.name} - Image ${index + 1}`}
-                            fill
-                            className="object-contain"
-                            priority={index === 0}
-                          />
-                        </div>
-                      </CarouselItem>
-                    ))}
-                  </CarouselContent>
-                  <CarouselPrevious className="-left-10 border-none bg-white/90 shadow-md hover:bg-white sm:-left-12" />
-                  <CarouselNext className="-right-10 border-none bg-white/90 shadow-md hover:bg-white sm:-right-12" />
-                </Carousel>
-              </div>
-            </DialogContent>
-          </Dialog>
-        ) : (
-          <Image
-            src={currentImage || "/placeholder.svg"}
-            alt={artist.name}
-            width={120}
-            height={120}
-            className="h-[120px] w-[120px] border-4 border-white object-cover shadow-[0_2px_8px_rgba(0,0,0,0.15)]"
-          />
-        )}
-      </div>
+      <div className="relative z-10 flex-shrink-0">{renderImageContent()}</div>
       <div className="relative z-10 min-w-0 flex-1">
         <h3 className="mb-1 text-xl font-medium text-gray-900">
           {artist.name}

--- a/src/app/components/artist-card.tsx
+++ b/src/app/components/artist-card.tsx
@@ -23,10 +23,48 @@ function formatWebsiteDisplay(link: string): string {
   return link.replace(/^https?:\/\//, "").replace(/^www\./, "");
 }
 
-/** Skeleton placeholder for image loading state */
+/** Skeleton placeholder for thumbnail loading state */
 function ImageSkeleton() {
   return (
     <div className="h-[120px] w-[120px] animate-pulse border-4 border-white bg-gray-200 shadow-[0_2px_8px_rgba(0,0,0,0.15)]" />
+  );
+}
+
+/** Skeleton placeholder for carousel image loading state */
+function CarouselImageSkeleton() {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      <div className="h-full w-full max-w-[80%] animate-pulse bg-gray-800/50" />
+    </div>
+  );
+}
+
+/** Carousel image with loading state */
+function CarouselImage({
+  src,
+  alt,
+  priority,
+}: {
+  src: string;
+  alt: string;
+  priority?: boolean;
+}) {
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  return (
+    <>
+      {!isLoaded && <CarouselImageSkeleton />}
+      <Image
+        src={src}
+        alt={alt}
+        fill
+        className={`object-contain transition-opacity duration-300 ${
+          isLoaded ? "opacity-100" : "opacity-0"
+        }`}
+        priority={priority}
+        onLoad={() => setIsLoaded(true)}
+      />
+    </>
   );
 }
 
@@ -119,11 +157,9 @@ export function ArtistCard({ artist }: { artist: Artist }) {
                   {images.map((image, index) => (
                     <CarouselItem key={image}>
                       <div className="relative h-[80vh] w-full sm:h-[70vh] sm:max-h-[600px]">
-                        <Image
+                        <CarouselImage
                           src={image}
                           alt={`${artist.name} - Image ${index + 1}`}
-                          fill
-                          className="object-contain"
                           priority={index === 0}
                         />
                       </div>

--- a/src/app/components/artist-card.tsx
+++ b/src/app/components/artist-card.tsx
@@ -160,7 +160,7 @@ export function ArtistCard({ artist }: { artist: Artist }) {
                         <CarouselImage
                           src={image}
                           alt={`${artist.name} - Image ${index + 1}`}
-                          priority={index === 0}
+                          priority={index === currentImageIndex}
                         />
                       </div>
                     </CarouselItem>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,27 +9,11 @@ import { getArtists } from "./helpers/get-artists";
 import { getCourses } from "./helpers/get-courses";
 import { getExpositions } from "./helpers/get-expositions";
 
-/** Ensure fresh random offsets on each request */
-export const dynamic = "force-dynamic";
-
 export default async function Component() {
   const expositions = await getExpositions();
   const artists = await getArtists();
   const courses = await getCourses();
   const agendaItems = await getAgendaItems();
-
-  /**
-   * Generate random image offsets server-side for stable hydration.
-   * Math.random() is safe here as server components only render once per request.
-   */
-  const artistImageOffsets = artists.map((artist) => {
-    const imageCount =
-      artist.all_images.length > 0
-        ? artist.all_images.length
-        : [artist.image, artist.flip_image].filter(Boolean).length;
-    // eslint-disable-next-line react-hooks/purity
-    return imageCount > 1 ? Math.floor(Math.random() * imageCount) : 0;
-  });
 
   /** Generate structured data for SEO */
   const structuredData = generateStructuredData(artists, courses);
@@ -83,11 +67,7 @@ export default async function Component() {
           {/* Artists Grid */}
           <div className="mx-auto grid max-w-4xl grid-cols-1 gap-8 md:grid-cols-2">
             {artists.map((artist, index) => (
-              <ArtistCard
-                key={index}
-                artist={artist}
-                initialImageOffset={artistImageOffsets[index]}
-              />
+              <ArtistCard key={index} artist={artist} />
             ))}
           </div>
 

--- a/src/hooks/use-scroll-based-images.tsx
+++ b/src/hooks/use-scroll-based-images.tsx
@@ -75,6 +75,9 @@ export function useScrollBasedImages({
 
     /** Calculate image index from current global state */
     const updateImageIndex = () => {
+      /** Guard against division by zero if images array becomes empty */
+      if (images.length === 0) return;
+
       const pixelsPerTransition = window.innerHeight / 2;
       const globalIndex = Math.floor(
         globalAccumulatedScroll / pixelsPerTransition,

--- a/src/hooks/use-scroll-based-images.tsx
+++ b/src/hooks/use-scroll-based-images.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 interface UseScrollBasedImagesProps {
   images: string[];
   enabled?: boolean;
-  /** Initial offset for the image index, typically provided server-side for stable hydration */
+  /** Initial offset for the image index, used for varied starting positions */
   initialOffset?: number;
 }
 
@@ -65,7 +65,7 @@ export function useScrollBasedImages({
   enabled = true,
   initialOffset = 0,
 }: UseScrollBasedImagesProps) {
-  /** Initialize with server-provided offset for stable hydration */
+  /** Initialize with provided offset for varied starting positions */
   const [currentImageIndex, setCurrentImageIndex] = useState(initialOffset);
 
   useEffect(() => {


### PR DESCRIPTION
Addresses feedback from the initial scroll behavior PR with several improvements:

- Fix race condition by using a single global scroll listener with pub/sub pattern instead of per-instance listeners
- Add guard against division by zero when images array becomes empty
- Defer image rendering to client-side with skeleton placeholder for stable hydration and true per-load randomness
- Add skeleton loading state for carousel images
- Remove force-dynamic to maintain static page generation
- Update README to document unlimited images per artist and new scroll behavior