### PR TITLE
Fix mobile scroll glitch by using fixed pixel threshold

### DIFF
--- a/src/hooks/use-scroll-based-images.tsx
+++ b/src/hooks/use-scroll-based-images.tsx
@@ -9,6 +9,9 @@ interface UseScrollBasedImagesProps {
   initialOffset?: number;
 }
 
+/** Fixed pixels per transition - stable across viewport changes (mobile browser chrome) */
+const PIXELS_PER_TRANSITION = 400;
+
 /** Shared scroll state across all hook instances */
 let globalAccumulatedScroll = 0;
 let lastScrollY = typeof window !== "undefined" ? window.scrollY : 0;
@@ -77,9 +80,8 @@ export function useScrollBasedImages({
       /** Guard against division by zero if images array becomes empty */
       if (images.length === 0) return;
 
-      const pixelsPerTransition = window.innerHeight / 2;
       const globalIndex = Math.floor(
-        globalAccumulatedScroll / pixelsPerTransition,
+        globalAccumulatedScroll / PIXELS_PER_TRANSITION,
       );
       const imageIndex = (globalIndex + initialOffset) % images.length;
       setCurrentImageIndex(imageIndex);


### PR DESCRIPTION
On mobile, `window.innerHeight` changes dynamically when the browser chrome (address bar) shows/hides during scrolling. This caused `pixelsPerTransition` to fluctuate, making the image index calculation unstable and resulting in rapid, glitchy transitions.

Replaced the dynamic `window.innerHeight / 2` calculation with a fixed `PIXELS_PER_TRANSITION = 400` constant, which provides consistent behavior across all devices and viewport states.