### PR TITLE
Mark Thijs' Synthesizer Magic as cancelled in program

### DIFF
--- a/content/expositions/15-jaar/15-jaar.md
+++ b/content/expositions/15-jaar/15-jaar.md
@@ -57,6 +57,6 @@ In 2026 bestaan de Ateliers Kersenboomgaard 15 jaar en dat gaan we groots vieren
 ### Hal 3
 
 - 12:00 – 16:00 — Expositie
-- 15:30 — Thijs' Synthesizer Magic
+- 15:30 — ~~Thijs' Synthesizer Magic~~ (afgelast)
 
 Programma onder voorbehoud.


### PR DESCRIPTION
Marks the "Thijs' Synthesizer Magic" item in the 15-jaar exposition program (Sunday 31 May, Hal 3, 15:30) as cancelled. The title is struck through and followed by "(afgelast)".

Scope: docs
Visibility: user-facing